### PR TITLE
Add award categories and voting to Hackweek app

### DIFF
--- a/database.rules.bolt
+++ b/database.rules.bolt
@@ -79,6 +79,13 @@ type Year {
     votingEnabled: Boolean | Null
 }
 
+type Vote {
+    creator: InitialUserRef,
+    project: ProjectRef,
+    awardCategory: AwardCategoryRef,
+    ts: Number
+}
+
 path / {
     read() { isAllowedUser() }
 }
@@ -105,6 +112,11 @@ path /years/{year} is Year {
         path /media/{mediaId} is ProjectMedia {}
 
         path /members/{memberId} is ProjectMember {}
+    }
+
+    path /votes/{voteId} is Vote {
+        write() { isAllowedUser() }
+        index() { ["creator", "awardCategory"]}
     }
 
     write() { isAdmin() }

--- a/database.rules.bolt
+++ b/database.rules.bolt
@@ -54,7 +54,7 @@ type Project {
 }
 
 type ProjectRef extends String {
-  validate() { this.parent().parent().projects[this] != null }
+  validate() { this.parent().parent().parent().projects[this] != null }
 }
 
 type Award {

--- a/database.rules.bolt
+++ b/database.rules.bolt
@@ -75,6 +75,10 @@ type AwardCategory {
     ts: InitialTimestamp
 }
 
+type Year {
+    votingEnabled: Boolean | Null
+}
+
 path / {
     read() { isAllowedUser() }
 }
@@ -83,7 +87,7 @@ path /users/{userId} is User {
     write() { isAllowedUser() && isCurrentUser(userId) }
 }
 
-path /years/{year} {
+path /years/{year} is Year {
     path /awardCategories/{awardCategoryId} is AwardCategory {
         write() { isAdmin() }
         index() { ["creator"] }
@@ -102,4 +106,6 @@ path /years/{year} {
 
         path /members/{memberId} is ProjectMember {}
     }
+
+    write() { isAdmin() }
 }

--- a/database.rules.bolt
+++ b/database.rules.bolt
@@ -64,6 +64,12 @@ type Award {
     ts: InitialTimestamp,
 }
 
+type AwardCategory {
+    creator: InitialUserRef,
+    name: String,
+    ts: InitialTimestamp
+}
+
 path / {
     read() { isAllowedUser() }
 }
@@ -73,6 +79,11 @@ path /users/{userId} is User {
 }
 
 path /years/{year} {
+    path /awardCategories/{awardCategoryId} is AwardCategory {
+        write() { isAdmin() }
+        index() { ["creator"] }
+    }
+
     path /awards/{awardId} is Award {
         write() { isAdmin() }
         index() { ["creator", "project"] }

--- a/database.rules.bolt
+++ b/database.rules.bolt
@@ -57,10 +57,15 @@ type ProjectRef extends String {
   validate() { this.parent().parent().parent().projects[this] != null }
 }
 
+type AwardCategoryRef extends String {
+    validate() { this.parent().parent().parent().awardCategories[this] != null }
+}
+
 type Award {
     creator: InitialUserRef,
     project: ProjectRef,
     name: String,
+    awardCategory: AwardCategoryRef,
     ts: InitialTimestamp,
 }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "bootstrap": "3",
-    "firebase": "^5.8",
+    "firebase": "7",
     "firebase-bolt": "^0.8",
     "idx": "^2.2.0",
     "marked": "^0.3.6",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -16,7 +16,7 @@ import {
   defaultsDeep,
 } from 'lodash';
 
-export const getPopulateObj = str => {
+export const getPopulateObj = (str) => {
   if (!isString(str)) {
     return str;
   }
@@ -25,11 +25,11 @@ export const getPopulateObj = str => {
   return {child: strArray[0], root: strArray[1]};
 };
 
-export const getPopulateObjs = arr => {
+export const getPopulateObjs = (arr) => {
   if (!isArray(arr)) {
     return arr;
   }
-  return arr.map(o => (isObject(o) ? o : getPopulateObj(o)));
+  return arr.map((o) => (isObject(o) ? o : getPopulateObj(o)));
 };
 
 /**
@@ -62,7 +62,7 @@ export const orderedPopulatedDataToJS = (data, path, populates, notSetValue) => 
       ? populates(last(split(path, '/')), dataToJS(data, path))
       : populates
   );
-  const dataHasPopluateChilds = every(populatesForData, populate =>
+  const dataHasPopluateChilds = every(populatesForData, (populate) =>
     has(dataToJS(data, path), populate.child)
   );
 

--- a/src/pages/ManageAwardCategories.js
+++ b/src/pages/ManageAwardCategories.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {compose} from 'redux';
 import {firebaseConnect, isLoaded, pathToJS} from 'react-redux-firebase';
-import Select from 'react-select';
 
 import {mapObject, orderedPopulatedDataToJS} from '../helpers';
 

--- a/src/pages/ManageAwardCategories.js
+++ b/src/pages/ManageAwardCategories.js
@@ -1,0 +1,180 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+
+import {connect} from 'react-redux';
+import {compose} from 'redux';
+import {firebaseConnect, isLoaded, pathToJS} from 'react-redux-firebase';
+import Select from 'react-select';
+
+import {mapObject, orderedPopulatedDataToJS} from '../helpers';
+
+class AwardCategoryRow extends Component {
+  static propTypes = {
+    awardCategory: PropTypes.object,
+    onDelete: PropTypes.func.isRequired,
+    onSave: PropTypes.func.isRequired,
+    year: PropTypes.string.isRequired,
+  };
+
+  static contextTypes = {
+    router: PropTypes.object.isRequired,
+  };
+
+  constructor(props, ...args) {
+    super(props, ...args);
+    this.state = {
+      name: '',
+      ...(props.awardCategory || {}),
+    };
+  }
+
+  onChangeField = (e) => {
+    this.setState({
+      [e.target.name]: e.target.value,
+    });
+  };
+
+  hasChanges() {
+    let {awardCategory} = this.props;
+    let state = this.state;
+    if (!awardCategory) return state.name;
+    return awardCategory.name !== state.name;
+  }
+
+  onSuccess = () => {
+    if (!this.props.awardCategory) {
+      this.setState({name: ''});
+    }
+  };
+
+  render() {
+    let {awardCategory} = this.props;
+    return (
+      <form
+        onSubmit={(e) =>
+          e.preventDefault() && this.props.onSave(this.state, this.onSuccess)
+        }
+        className="form Award-Form"
+      >
+        <div className="row">
+          <div className="col-sm-5">
+            <input
+              className="form-control"
+              type="text"
+              name="name"
+              value={this.state.name}
+              onChange={this.onChangeField}
+              required
+            />
+          </div>
+          <div className="col-sm-2">
+            <button
+              className="btn btn-primary"
+              disabled={!this.hasChanges()}
+              onClick={() => this.props.onSave(this.state, this.onSuccess)}
+            >
+              <span className="glyphicon glyphicon-ok" />
+            </button>
+            {!!awardCategory && (
+              <button
+                className="btn btn-danger"
+                style={{marginLeft: 5}}
+                onClick={() => this.props.onDelete(this.state)}
+              >
+                <span className="glyphicon glyphicon-remove" />
+              </button>
+            )}
+          </div>
+        </div>
+      </form>
+    );
+  }
+}
+
+class ManageAwardCategories extends Component {
+  static propTypes = {
+    auth: PropTypes.object,
+    awardCategoryList: PropTypes.object,
+    firebase: PropTypes.object,
+  };
+
+  static contextTypes = {
+    router: PropTypes.object.isRequired,
+  };
+
+  constructor(...args) {
+    super(...args);
+    this.state = {};
+  }
+
+  onDelete = (award) => {
+    let {firebase, params} = this.props;
+    firebase.remove(`/years/${params.year}/awardCategories/${award.key}`);
+  };
+
+  onSave = (award, onSuccess) => {
+    let {auth, firebase, params} = this.props;
+    let {year} = params;
+    if (award.key) {
+      firebase
+        .update(`/years/${year}/awardCategories/${award.key}`, {
+          name: award.name,
+        })
+        .then(onSuccess);
+    } else {
+      firebase
+        .push(`/years/${year}/awardCategories`, {
+          name: award.name,
+          ts: Date.now(),
+          creator: auth.uid,
+        })
+        .then(onSuccess);
+    }
+  };
+
+  render() {
+    let {awardCategoryList, auth} = this.props;
+    if (!isLoaded(auth) || !isLoaded(awardCategoryList))
+      return <div className="loading-indocator">Loading...</div>;
+
+    let {year} = this.props.params;
+
+    return (
+      <div>
+        {mapObject(awardCategoryList)
+          .sort((a, b) => ('' + a.name).localeCompare(b.name))
+          .map((awardCategory) => (
+            <AwardCategoryRow
+              key={awardCategory.key}
+              awardCategory={awardCategory}
+              onSave={this.onSave}
+              onDelete={this.onDelete}
+              year={year}
+            />
+          ))}
+        <AwardCategoryRow onSave={this.onSave} onDelete={this.onDelete} year={year} />
+      </div>
+    );
+  }
+}
+
+const keyPopulates = [{keyProp: 'key'}];
+
+export default compose(
+  firebaseConnect(({params}) => [
+    {
+      path: `/years/${params.year}/awardCategories`,
+      queryParams: ['orderByChild=name'],
+      populates: keyPopulates,
+      storeAs: 'awardCategoryList',
+    },
+  ]),
+  connect(({firebase}) => ({
+    auth: pathToJS(firebase, 'auth'),
+    awardCategoryList: orderedPopulatedDataToJS(
+      firebase,
+      'awardCategoryList',
+      keyPopulates
+    ),
+  }))
+)(ManageAwardCategories);

--- a/src/pages/ManageYear.js
+++ b/src/pages/ManageYear.js
@@ -33,6 +33,9 @@ class ManageYear extends Component {
           <ListLink to={`/admin/years/${yearKey}`} index={true}>
             Overview
           </ListLink>
+          <ListLink to={`/admin/years/${yearKey}/award-categories`}>
+            Award Categories
+          </ListLink>
           <ListLink to={`/admin/years/${yearKey}/awards`}>Awards</ListLink>
         </ul>
         {this.props.children}

--- a/src/pages/ManageYearDetails.js
+++ b/src/pages/ManageYearDetails.js
@@ -18,6 +18,23 @@ class ManageYearDetails extends Component {
     router: PropTypes.object.isRequired,
   };
 
+  constructor(props, ...args) {
+    super(props, ...args);
+    this.state = {
+      votingEnabled: props.year.votingEnabled,
+    };
+  }
+
+  onVotingChange = (e) => {
+    let {firebase, params} = this.props;
+    let {year} = params;
+
+    let votingEnabled = e.target.checked;
+    this.setState({votingEnabled}, () => {
+      firebase.update(`/years/${year}/`, {votingEnabled});
+    });
+  };
+
   render() {
     let {year} = this.props;
     if (!isLoaded(year)) return <div className="loading-indocator">Loading...</div>;
@@ -35,8 +52,18 @@ class ManageYearDetails extends Component {
               type="text"
               name="year"
               value={yearKey}
-              readonly
+              readOnly
               disabled
+            />
+          </div>
+          <div className="form-group">
+            <label>Voting Enabled</label>
+            <input
+              className="form-control"
+              type="checkbox"
+              name="votingEnabled"
+              checked={this.state.votingEnabled}
+              onChange={this.onVotingChange}
             />
           </div>
         </div>

--- a/src/pages/ProjectDetails.js
+++ b/src/pages/ProjectDetails.js
@@ -37,6 +37,7 @@ class ProjectVote extends Component {
     awardCategoryList: PropTypes.array,
     userVote: PropTypes.string,
     onSave: PropTypes.func,
+    disabled: PropTypes.bool,
   };
 
   constructor(props, ...args) {
@@ -72,6 +73,7 @@ class ProjectVote extends Component {
             value={this.state.userVote}
             multi={false}
             options={awardCategoryOptions}
+            disabled={this.props.disabled}
             onChange={this.onChangeVote}
           />
         </div>
@@ -137,7 +139,9 @@ class ProjectDetails extends Component {
     let year = params.year || currentYear;
     let {projectKey} = this.props.params;
 
-    let vote = this.state.userVote;
+    if (this.isProjectMember()) {
+      return; // no-op attempt to vote for your own project
+    }
 
     // Enforce unique constraint by having key by combination of
     // user and award category
@@ -150,6 +154,10 @@ class ProjectDetails extends Component {
       ts: Date.now(),
     });
   };
+
+  isProjectMember() {
+    return (this.props.project.members || {}).hasOwnProperty(this.props.auth.uid);
+  }
   render() {
     let {
       auth,
@@ -194,10 +202,7 @@ class ProjectDetails extends Component {
 
     let projectKey = this.props.params.projectKey;
 
-    let canEdit =
-      profile.admin ||
-      (project.members || {}).hasOwnProperty(auth.uid) ||
-      !projectMembers.length;
+    let canEdit = profile.admin || this.isProjectMember() || !projectMembers.length;
 
     let creator = userList[project.creator] || null;
 
@@ -324,6 +329,7 @@ class ProjectDetails extends Component {
                   userVote={
                     this.state.userVote ? this.state.userVote.awardCategory : null
                   }
+                  disabled={this.isProjectMember()}
                   onSave={this.onSaveUserVote}
                 />
               ) : (

--- a/src/pages/ProjectDetails.js
+++ b/src/pages/ProjectDetails.js
@@ -16,14 +16,15 @@ import Avatar from '../components/Avatar';
 import Layout from '../components/Layout';
 import MediaObject from '../components/MediaObject';
 
-function Awards({awardList}) {
-  return awardList && awardList.length ? (
+function Awards({awards, awardCategories}) {
+  return awards && awards.length ? (
     <div className="Project-meta" key="awards">
       <h3>Awards</h3>
       <ul className="Project-award-list">
-        {awardList.map((award) => (
+        {awards.map((award) => (
           <li key={award.key}>
-            <span className="glyphicon glyphicon-star" /> {award.name}
+            <span className="glyphicon glyphicon-star" />{' '}
+            {awardCategories.find((ac) => ac.key === award.awardCategory).name}
           </li>
         ))}
       </ul>
@@ -61,7 +62,6 @@ class ProjectVote extends Component {
         value: awardCategory.key,
         label: awardCategory.name,
       }));
-    console.log(this.state.userVote);
 
     return (
       <div className="Project-meta" key="awards">
@@ -202,7 +202,7 @@ class ProjectDetails extends Component {
     let creator = userList[project.creator] || null;
 
     let awards = mapObject(awardList).filter((award) => award.project === projectKey);
-    console.log(this.state.userVote);
+
     return (
       <Layout>
         <div className="Project-Details">
@@ -327,7 +327,7 @@ class ProjectDetails extends Component {
                   onSave={this.onSaveUserVote}
                 />
               ) : (
-                <Awards awards={awards} />
+                <Awards awards={awards} awardCategories={awardCategories} />
               )}
 
               <div className="Project-meta" key="meta">

--- a/src/pages/ProjectDetails.js
+++ b/src/pages/ProjectDetails.js
@@ -139,19 +139,16 @@ class ProjectDetails extends Component {
 
     let vote = this.state.userVote;
 
-    if (vote && vote.key) {
-      firebase.update(`/years/${year}/votes/${vote.key}`, {
-        project: projectKey,
-        awardCategory: awardCategoryKey,
-      });
-    } else {
-      firebase.push(`/years/${year}/votes`, {
-        project: projectKey,
-        awardCategory: awardCategoryKey,
-        ts: Date.now(),
-        creator: auth.uid,
-      });
-    }
+    // Enforce unique constraint by having key by combination of
+    // user and award category
+    let voteKey = auth.uid + ':' + awardCategoryKey;
+
+    firebase.ref(`years/${year}/votes/${voteKey}`).set({
+      creator: auth.uid,
+      project: projectKey,
+      awardCategory: awardCategoryKey,
+      ts: Date.now(),
+    });
   };
   render() {
     let {

--- a/src/pages/ProjectList.css
+++ b/src/pages/ProjectList.css
@@ -12,8 +12,15 @@
   text-align: left;
 }
 
-.Project-award {
+.Project-award,
+.Project-vote {
   float: right;
+}
+.Project-vote {
+  font-style: italic;
+}
+.Project-award {
+  margin-left: 1em;
 }
 
 .Project-summary {

--- a/src/pages/ProjectList.css
+++ b/src/pages/ProjectList.css
@@ -70,6 +70,7 @@
 
 .Project-meta {
   font-size: 0.8em;
+  margin-bottom: 20px;
 }
 
 .Project-media {

--- a/src/pages/ProjectList.js
+++ b/src/pages/ProjectList.js
@@ -30,7 +30,7 @@ class ProjectListItem extends Component {
     firebase: PropTypes.object,
     project: PropTypes.object,
     userList: PropTypes.object,
-    userVote: PropTypes.object,
+    userVote: PropTypes.array,
   };
 
   render() {
@@ -319,6 +319,11 @@ class ProjectList extends Component {
           <div className="alert alert-block alert-info">
             You're viewing an archive of Hackweek projects for {this.props.params.year}{' '}
             &mdash; <Link to="/projects">Fast forward to {currentYear}</Link>
+          </div>
+        )}
+        {this.props.year && this.props.year.votingEnabled && (
+          <div className="alert alert-block alert-info">
+            Voting is currently enabled! Visit a project to cast your vote &hellip;
           </div>
         )}
         {this.renderBody()}

--- a/src/routes.js
+++ b/src/routes.js
@@ -10,6 +10,7 @@ import ProjectDetails from './pages/ProjectDetails';
 import YearList from './pages/YearList';
 
 import Admin from './pages/Admin';
+import ManageAwardCategories from './pages/ManageAwardCategories';
 import ManageAwards from './pages/ManageAwards';
 import ManageYear from './pages/ManageYear';
 import ManageYearDetails from './pages/ManageYearDetails';
@@ -44,6 +45,10 @@ export default (
     <Route path="/admin" component={loginRequired(Admin)} />
     <Route path="/admin/years/:year" component={loginRequired(ManageYear)}>
       <IndexRoute component={loginRequired(ManageYearDetails)} />
+      <Route
+        path="/admin/years/:year/award-categories"
+        component={loginRequired(ManageAwardCategories)}
+      />
       <Route path="/admin/years/:year/awards" component={loginRequired(ManageAwards)} />
     </Route>
   </Route>

--- a/yarn.lock
+++ b/yarn.lock
@@ -812,141 +812,213 @@
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-9.0.1.tgz#c27b391d8457d1e893f1eddeaf5e5412d12ffbb5"
 
-"@firebase/app-types@0.3.10":
-  version "0.3.10"
-  resolved "https://registry.yarnpkg.com/@firebase/app-types/-/app-types-0.3.10.tgz#8f6d24d80bf833622b53ed26eaa04cfa9dd0f2f3"
+"@firebase/analytics-types@0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@firebase/analytics-types/-/analytics-types-0.3.1.tgz#3c5f5d71129c88295e17e914e34b391ffda1723c"
 
-"@firebase/app@0.3.17":
-  version "0.3.17"
-  resolved "https://registry.yarnpkg.com/@firebase/app/-/app-0.3.17.tgz#491dc3bc1a2837bbb4869161cc9852cfc04da891"
+"@firebase/analytics@0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@firebase/analytics/-/analytics-0.4.1.tgz#0f1e6f4e56af11c3956b1652520095a1fbd2c418"
   dependencies:
-    "@firebase/app-types" "0.3.10"
-    "@firebase/util" "0.2.14"
+    "@firebase/analytics-types" "0.3.1"
+    "@firebase/component" "0.1.17"
+    "@firebase/installations" "0.4.15"
+    "@firebase/logger" "0.2.6"
+    "@firebase/util" "0.3.0"
+    tslib "^1.11.1"
+
+"@firebase/app-types@0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@firebase/app-types/-/app-types-0.6.1.tgz#dcbd23030a71c0c74fc95d4a3f75ba81653850e9"
+
+"@firebase/app@0.6.9":
+  version "0.6.9"
+  resolved "https://registry.yarnpkg.com/@firebase/app/-/app-0.6.9.tgz#e60412d9b6012afb73caef2a1353e1b4c4182954"
+  dependencies:
+    "@firebase/app-types" "0.6.1"
+    "@firebase/component" "0.1.17"
+    "@firebase/logger" "0.2.6"
+    "@firebase/util" "0.3.0"
     dom-storage "2.1.0"
-    tslib "1.9.3"
+    tslib "^1.11.1"
     xmlhttprequest "1.8.0"
 
-"@firebase/auth-types@0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@firebase/auth-types/-/auth-types-0.6.1.tgz#9b60142e3a4adc1db09c037d068ab98cd54c10a8"
+"@firebase/auth-interop-types@0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@firebase/auth-interop-types/-/auth-interop-types-0.1.5.tgz#9fc9bd7c879f16b8d1bb08373a0f48c3a8b74557"
 
-"@firebase/auth@0.10.2":
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/@firebase/auth/-/auth-0.10.2.tgz#ef7a34f4667445ebaf4972622141c8fa4dffb961"
+"@firebase/auth-types@0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@firebase/auth-types/-/auth-types-0.10.1.tgz#7815e71c9c6f072034415524b29ca8f1d1770660"
+
+"@firebase/auth@0.14.9":
+  version "0.14.9"
+  resolved "https://registry.yarnpkg.com/@firebase/auth/-/auth-0.14.9.tgz#481db24d5bd6eded8ac2e5aea6edb9307040229c"
   dependencies:
-    "@firebase/auth-types" "0.6.1"
+    "@firebase/auth-types" "0.10.1"
 
-"@firebase/database-types@0.3.11":
-  version "0.3.11"
-  resolved "https://registry.yarnpkg.com/@firebase/database-types/-/database-types-0.3.11.tgz#6bfcaca8e14e7d6bb67d723f0c2d7febbeefa054"
-
-"@firebase/database@0.3.20":
-  version "0.3.20"
-  resolved "https://registry.yarnpkg.com/@firebase/database/-/database-0.3.20.tgz#6851d8ef3229aeb7bcbe5e851434672abae43ee4"
+"@firebase/component@0.1.17":
+  version "0.1.17"
+  resolved "https://registry.yarnpkg.com/@firebase/component/-/component-0.1.17.tgz#2ce3e1aa060eccf0f06d20368ef9a32cf07c07be"
   dependencies:
-    "@firebase/database-types" "0.3.11"
-    "@firebase/logger" "0.1.13"
-    "@firebase/util" "0.2.14"
-    faye-websocket "0.11.1"
-    tslib "1.9.3"
+    "@firebase/util" "0.3.0"
+    tslib "^1.11.1"
 
-"@firebase/firestore-types@1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@firebase/firestore-types/-/firestore-types-1.2.1.tgz#ac09c2e1b6324991cd05c1ce1f74e63771237fb8"
-
-"@firebase/firestore@1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@firebase/firestore/-/firestore-1.2.2.tgz#9a97e60cc20bda7b06a6985190b4f33357a4fe28"
+"@firebase/database-types@0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@firebase/database-types/-/database-types-0.5.1.tgz#fab2f3fb48eec374a9f435ed21e138635cb9b71c"
   dependencies:
-    "@firebase/firestore-types" "1.2.1"
-    "@firebase/logger" "0.1.13"
-    "@firebase/webchannel-wrapper" "0.2.19"
-    grpc "1.20.0"
-    tslib "1.9.3"
+    "@firebase/app-types" "0.6.1"
 
-"@firebase/functions-types@0.3.5":
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/@firebase/functions-types/-/functions-types-0.3.5.tgz#1fae28b0bbb89fd0629a353eafbc53e8d6e073e2"
-
-"@firebase/functions@0.4.6":
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/@firebase/functions/-/functions-0.4.6.tgz#be6a3bac1779ec612c6bf8082464319d22607a84"
+"@firebase/database@0.6.9":
+  version "0.6.9"
+  resolved "https://registry.yarnpkg.com/@firebase/database/-/database-0.6.9.tgz#18a4bdc93b0b10c19a8ad4ff616bba196e5a16e0"
   dependencies:
-    "@firebase/functions-types" "0.3.5"
-    "@firebase/messaging-types" "0.2.11"
+    "@firebase/auth-interop-types" "0.1.5"
+    "@firebase/component" "0.1.17"
+    "@firebase/database-types" "0.5.1"
+    "@firebase/logger" "0.2.6"
+    "@firebase/util" "0.3.0"
+    faye-websocket "0.11.3"
+    tslib "^1.11.1"
+
+"@firebase/firestore-types@1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@firebase/firestore-types/-/firestore-types-1.12.0.tgz#511e572e946b07f5a603c90e078f0cd714923fac"
+
+"@firebase/firestore@1.16.2":
+  version "1.16.2"
+  resolved "https://registry.yarnpkg.com/@firebase/firestore/-/firestore-1.16.2.tgz#66eedeefab569331efc1ad9ab49a8f1c867a9163"
+  dependencies:
+    "@firebase/component" "0.1.17"
+    "@firebase/firestore-types" "1.12.0"
+    "@firebase/logger" "0.2.6"
+    "@firebase/util" "0.3.0"
+    "@firebase/webchannel-wrapper" "0.2.41"
+    "@grpc/grpc-js" "^1.0.0"
+    "@grpc/proto-loader" "^0.5.0"
+    tslib "^1.11.1"
+
+"@firebase/functions-types@0.3.17":
+  version "0.3.17"
+  resolved "https://registry.yarnpkg.com/@firebase/functions-types/-/functions-types-0.3.17.tgz#348bf5528b238eeeeeae1d52e8ca547b21d33a94"
+
+"@firebase/functions@0.4.49":
+  version "0.4.49"
+  resolved "https://registry.yarnpkg.com/@firebase/functions/-/functions-0.4.49.tgz#cca60a2f8e188e020c7e5a5ecf075474885ffb03"
+  dependencies:
+    "@firebase/component" "0.1.17"
+    "@firebase/functions-types" "0.3.17"
+    "@firebase/messaging-types" "0.4.5"
     isomorphic-fetch "2.2.1"
-    tslib "1.9.3"
+    tslib "^1.11.1"
 
-"@firebase/installations-types@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@firebase/installations-types/-/installations-types-0.1.0.tgz#51c2d93d91ae6539f1a292f8d58d3d83e98cc9a2"
+"@firebase/installations-types@0.3.4":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@firebase/installations-types/-/installations-types-0.3.4.tgz#589a941d713f4f64bf9f4feb7f463505bab1afa2"
 
-"@firebase/installations@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@firebase/installations/-/installations-0.1.0.tgz#7a738a5d647e611cd47666f95982af6049dc9d00"
+"@firebase/installations@0.4.15":
+  version "0.4.15"
+  resolved "https://registry.yarnpkg.com/@firebase/installations/-/installations-0.4.15.tgz#ec5a098aea6b5e3e29e73270eeaaf9791587d20a"
   dependencies:
-    "@firebase/installations-types" "0.1.0"
-    "@firebase/util" "0.2.14"
+    "@firebase/component" "0.1.17"
+    "@firebase/installations-types" "0.3.4"
+    "@firebase/util" "0.3.0"
     idb "3.0.2"
+    tslib "^1.11.1"
 
-"@firebase/logger@0.1.13":
-  version "0.1.13"
-  resolved "https://registry.yarnpkg.com/@firebase/logger/-/logger-0.1.13.tgz#8e4847a0d5b77cedd8dcf4c6a8e4b98de7297e6b"
+"@firebase/logger@0.2.6":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@firebase/logger/-/logger-0.2.6.tgz#3aa2ca4fe10327cabf7808bd3994e88db26d7989"
 
-"@firebase/messaging-types@0.2.11":
-  version "0.2.11"
-  resolved "https://registry.yarnpkg.com/@firebase/messaging-types/-/messaging-types-0.2.11.tgz#b81d09c0aa6be7dbac421edff8100971c56d64e0"
+"@firebase/messaging-types@0.4.5":
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/@firebase/messaging-types/-/messaging-types-0.4.5.tgz#452572d3c5b7fa83659fdb1884450477229f5dc4"
 
-"@firebase/messaging@0.3.19":
-  version "0.3.19"
-  resolved "https://registry.yarnpkg.com/@firebase/messaging/-/messaging-0.3.19.tgz#d66d83f18b219a7059f78fca1eb5ebc25474c093"
+"@firebase/messaging@0.6.21":
+  version "0.6.21"
+  resolved "https://registry.yarnpkg.com/@firebase/messaging/-/messaging-0.6.21.tgz#d301de72ad055c3f302b917b8a11373cd78c7431"
   dependencies:
-    "@firebase/messaging-types" "0.2.11"
-    "@firebase/util" "0.2.14"
-    tslib "1.9.3"
+    "@firebase/component" "0.1.17"
+    "@firebase/installations" "0.4.15"
+    "@firebase/messaging-types" "0.4.5"
+    "@firebase/util" "0.3.0"
+    idb "3.0.2"
+    tslib "^1.11.1"
 
-"@firebase/performance-types@0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@firebase/performance-types/-/performance-types-0.0.1.tgz#749b6351f5f802ec7a9be5737546eeda18e7ac4a"
+"@firebase/performance-types@0.0.13":
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/@firebase/performance-types/-/performance-types-0.0.13.tgz#58ce5453f57e34b18186f74ef11550dfc558ede6"
 
-"@firebase/performance@0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@firebase/performance/-/performance-0.2.1.tgz#14cf8c747672ca529cc6d07234ef5baab227d4c9"
+"@firebase/performance@0.3.10":
+  version "0.3.10"
+  resolved "https://registry.yarnpkg.com/@firebase/performance/-/performance-0.3.10.tgz#b68336e23f4b5422bd67f6ce35e28293a6b8945e"
   dependencies:
-    "@firebase/installations" "0.1.0"
-    "@firebase/logger" "0.1.13"
-    "@firebase/performance-types" "0.0.1"
-    "@firebase/util" "0.2.14"
-    tslib "1.9.3"
+    "@firebase/component" "0.1.17"
+    "@firebase/installations" "0.4.15"
+    "@firebase/logger" "0.2.6"
+    "@firebase/performance-types" "0.0.13"
+    "@firebase/util" "0.3.0"
+    tslib "^1.11.1"
 
-"@firebase/polyfill@0.3.13":
-  version "0.3.13"
-  resolved "https://registry.yarnpkg.com/@firebase/polyfill/-/polyfill-0.3.13.tgz#f08570ea6429e3ef5f8daa4df62c6b7ad2501908"
+"@firebase/polyfill@0.3.36":
+  version "0.3.36"
+  resolved "https://registry.yarnpkg.com/@firebase/polyfill/-/polyfill-0.3.36.tgz#c057cce6748170f36966b555749472b25efdb145"
   dependencies:
-    core-js "3.0.1"
-    promise-polyfill "8.1.0"
+    core-js "3.6.5"
+    promise-polyfill "8.1.3"
     whatwg-fetch "2.0.4"
 
-"@firebase/storage-types@0.2.11":
-  version "0.2.11"
-  resolved "https://registry.yarnpkg.com/@firebase/storage-types/-/storage-types-0.2.11.tgz#cbbcdca9bbd68c527ca2c2be2241d619126cb5b3"
+"@firebase/remote-config-types@0.1.9":
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/@firebase/remote-config-types/-/remote-config-types-0.1.9.tgz#fe6bbe4d08f3b6e92fce30e4b7a9f4d6a96d6965"
 
-"@firebase/storage@0.2.15":
-  version "0.2.15"
-  resolved "https://registry.yarnpkg.com/@firebase/storage/-/storage-0.2.15.tgz#64a4bf101a08c5e24cf398fe02d3d2a65a1fd2e9"
+"@firebase/remote-config@0.1.26":
+  version "0.1.26"
+  resolved "https://registry.yarnpkg.com/@firebase/remote-config/-/remote-config-0.1.26.tgz#62f448237bc46b986c27ac623b5cc5852007ea05"
   dependencies:
-    "@firebase/storage-types" "0.2.11"
-    tslib "1.9.3"
+    "@firebase/component" "0.1.17"
+    "@firebase/installations" "0.4.15"
+    "@firebase/logger" "0.2.6"
+    "@firebase/remote-config-types" "0.1.9"
+    "@firebase/util" "0.3.0"
+    tslib "^1.11.1"
 
-"@firebase/util@0.2.14":
-  version "0.2.14"
-  resolved "https://registry.yarnpkg.com/@firebase/util/-/util-0.2.14.tgz#c22911407453436d0f472c8d408791a6bd5feb9c"
+"@firebase/storage-types@0.3.13":
+  version "0.3.13"
+  resolved "https://registry.yarnpkg.com/@firebase/storage-types/-/storage-types-0.3.13.tgz#cd43e939a2ab5742e109eb639a313673a48b5458"
+
+"@firebase/storage@0.3.41":
+  version "0.3.41"
+  resolved "https://registry.yarnpkg.com/@firebase/storage/-/storage-0.3.41.tgz#cba8946f980d70e68d52cfb110ad109592a645d0"
   dependencies:
-    tslib "1.9.3"
+    "@firebase/component" "0.1.17"
+    "@firebase/storage-types" "0.3.13"
+    "@firebase/util" "0.3.0"
+    tslib "^1.11.1"
 
-"@firebase/webchannel-wrapper@0.2.19":
-  version "0.2.19"
-  resolved "https://registry.yarnpkg.com/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.2.19.tgz#991df31d892a51414e0e544b5cff4216cfb04915"
+"@firebase/util@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@firebase/util/-/util-0.3.0.tgz#c3e938192cde4e1c6260aecaaf22103add2352f5"
+  dependencies:
+    tslib "^1.11.1"
+
+"@firebase/webchannel-wrapper@0.2.41":
+  version "0.2.41"
+  resolved "https://registry.yarnpkg.com/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.2.41.tgz#4e470c25a99fa0b1f629f1c5ef180a318d399fd0"
+
+"@grpc/grpc-js@^1.0.0":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.1.3.tgz#0b91b166d744b6a43b00430dceff0f0ff88c98d5"
+  dependencies:
+    semver "^6.2.0"
+
+"@grpc/proto-loader@^0.5.0":
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.5.5.tgz#6725e7a1827bdf8e92e29fbf4e9ef0203c0906a9"
+  dependencies:
+    lodash.camelcase "^4.3.0"
+    protobufjs "^6.8.6"
 
 "@hapi/address@2.x.x":
   version "2.0.0"
@@ -1117,6 +1189,49 @@
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
 
+"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
+
+"@protobufjs/base64@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
+
+"@protobufjs/codegen@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
+
+"@protobufjs/eventemitter@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
+
+"@protobufjs/fetch@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.0.tgz#ba99fb598614af65700c1619ff06d454b0d84c45"
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
+    "@protobufjs/inquire" "^1.1.0"
+
+"@protobufjs/float@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
+
+"@protobufjs/inquire@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
+
+"@protobufjs/path@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
+
+"@protobufjs/pool@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
+
+"@protobufjs/utf8@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
+
 "@svgr/babel-plugin-add-jsx-attribute@^4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz#dadcb6218503532d6884b210e7f3c502caaa44b1"
@@ -1254,9 +1369,17 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/long@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
+
 "@types/node@*":
   version "12.0.7"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.7.tgz#4f2563bad652b2acb1722d7e7aae2b0ff62d192c"
+
+"@types/node@^13.7.0":
+  version "13.13.15"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.15.tgz#fe1cc3aa465a3ea6858b793fd380b66c39919766"
 
 "@types/q@^1.5.1":
   version "1.5.2"
@@ -1649,13 +1772,6 @@ arrify@^1.0.1:
 asap@~2.0.3, asap@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
-
-ascli@~1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/ascli/-/ascli-1.0.1.tgz#bcfa5974a62f18e81cabaeb49732ab4a88f906bc"
-  dependencies:
-    colour "~0.7.1"
-    optjs "~3.2.2"
 
 asn1.js@^4.0.0:
   version "4.10.1"
@@ -2107,12 +2223,6 @@ builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
 
-bytebuffer@~5:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/bytebuffer/-/bytebuffer-5.0.1.tgz#582eea4b1a873b6d020a48d58df85f0bba6cfddd"
-  dependencies:
-    long "~3"
-
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
@@ -2184,10 +2294,6 @@ camel-case@3.0.x:
   dependencies:
     no-case "^2.2.0"
     upper-case "^1.1.1"
-
-camelcase@^2.0.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
 
 camelcase@^4.1.0:
   version "4.1.0"
@@ -2330,14 +2436,6 @@ cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
 
-cliui@^3.0.3:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz#120601537a916d29940f934da3b48d585a39213d"
-  dependencies:
-    string-width "^1.0.1"
-    strip-ansi "^3.0.1"
-    wrap-ansi "^2.0.0"
-
 cliui@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
@@ -2415,10 +2513,6 @@ color@^3.0.0:
   dependencies:
     color-convert "^1.9.1"
     color-string "^1.5.2"
-
-colour@~0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/colour/-/colour-0.7.1.tgz#9cb169917ec5d12c0736d3e8685746df1cadf778"
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"
@@ -2569,6 +2663,10 @@ core-js-pure@3.1.3:
 core-js@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.0.1.tgz#1343182634298f7f38622f95e73f54e48ddf4738"
+
+core-js@3.6.5:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -2885,7 +2983,7 @@ debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-decamelize@^1.1.1, decamelize@^1.2.0:
+decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
@@ -3619,9 +3717,9 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-faye-websocket@0.11.1:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.1.tgz#f0efe18c4f56e4f40afc7e06c719fd5ee6188f38"
+faye-websocket@0.11.3, faye-websocket@~0.11.1:
+  version "0.11.3"
+  resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.3.tgz#5c0e9a8968e8912c286639fde977a8b209f2508e"
   dependencies:
     websocket-driver ">=0.5.1"
 
@@ -3634,12 +3732,6 @@ faye-websocket@0.9.3:
 faye-websocket@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.10.0.tgz#4e492f8d04dfb6f89003507f6edbf2d501e7c6f4"
-  dependencies:
-    websocket-driver ">=0.5.1"
-
-faye-websocket@~0.11.1:
-  version "0.11.3"
-  resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.3.tgz#5c0e9a8968e8912c286639fde977a8b209f2508e"
   dependencies:
     websocket-driver ">=0.5.1"
 
@@ -3758,6 +3850,25 @@ firebase-token-generator@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/firebase-token-generator/-/firebase-token-generator-2.0.0.tgz#9767d759ec13abdc99ba115fd5ea99d8b93d1206"
 
+firebase@7:
+  version "7.17.1"
+  resolved "https://registry.yarnpkg.com/firebase/-/firebase-7.17.1.tgz#6b2566d91a820a7993e3d2c75435f8baaabb58bb"
+  dependencies:
+    "@firebase/analytics" "0.4.1"
+    "@firebase/app" "0.6.9"
+    "@firebase/app-types" "0.6.1"
+    "@firebase/auth" "0.14.9"
+    "@firebase/database" "0.6.9"
+    "@firebase/firestore" "1.16.2"
+    "@firebase/functions" "0.4.49"
+    "@firebase/installations" "0.4.15"
+    "@firebase/messaging" "0.6.21"
+    "@firebase/performance" "0.3.10"
+    "@firebase/polyfill" "0.3.36"
+    "@firebase/remote-config" "0.1.26"
+    "@firebase/storage" "0.3.41"
+    "@firebase/util" "0.3.0"
+
 firebase@^3.9.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/firebase/-/firebase-3.9.0.tgz#c4237f50f58eeb25081b1839d6cbf175f8f7ed9b"
@@ -3767,20 +3878,6 @@ firebase@^3.9.0:
     jsonwebtoken "^7.3.0"
     promise-polyfill "^6.0.2"
     xmlhttprequest "^1.8.0"
-
-firebase@^5.8:
-  version "5.11.1"
-  resolved "https://registry.yarnpkg.com/firebase/-/firebase-5.11.1.tgz#e7d376265545d7b0538b4679a96145c26a2b5c39"
-  dependencies:
-    "@firebase/app" "0.3.17"
-    "@firebase/auth" "0.10.2"
-    "@firebase/database" "0.3.20"
-    "@firebase/firestore" "1.2.2"
-    "@firebase/functions" "0.4.6"
-    "@firebase/messaging" "0.3.19"
-    "@firebase/performance" "0.2.1"
-    "@firebase/polyfill" "0.3.13"
-    "@firebase/storage" "0.2.15"
 
 flat-cache@^2.0.1:
   version "2.0.1"
@@ -3979,7 +4076,7 @@ glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
 
-glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
+glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
   dependencies:
@@ -4037,16 +4134,6 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
-
-grpc@1.20.0:
-  version "1.20.0"
-  resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.20.0.tgz#85ad2aeb94bdbfe59c4a40b2fff8fc1ea70cd6a0"
-  dependencies:
-    lodash.camelcase "^4.3.0"
-    lodash.clone "^4.5.0"
-    nan "^2.0.0"
-    node-pre-gyp "^0.12.0"
-    protobufjs "^5.0.3"
 
 gzip-size@5.0.0:
   version "5.0.0"
@@ -4512,10 +4599,6 @@ invariant@^2.1.0, invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.4:
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
     loose-envify "^1.0.0"
-
-invert-kv@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
 invert-kv@^2.0.0:
   version "2.0.0"
@@ -5443,12 +5526,6 @@ lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
 
-lcid@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
-  dependencies:
-    invert-kv "^1.0.0"
-
 lcid@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf"
@@ -5533,10 +5610,6 @@ lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
 
-lodash.clone@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.5.0.tgz#195870450f5a13192478df4bc3d23d2dea1907b6"
-
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -5582,9 +5655,9 @@ loglevel@^1.4.1:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.3.tgz#77f2eb64be55a404c9fd04ad16d57c1d6d6b1280"
 
-long@~3:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/long/-/long-3.2.0.tgz#d821b7138ca1cb581c172990ef14db200b5c474b"
+long@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
@@ -5883,7 +5956,7 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-nan@^2.0.0, nan@^2.12.1:
+nan@^2.12.1:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
 
@@ -6226,10 +6299,6 @@ optionator@^0.8.1, optionator@^0.8.2:
     type-check "~0.3.2"
     wordwrap "~1.0.0"
 
-optjs@~3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/optjs/-/optjs-3.2.2.tgz#69a6ce89c442a44403141ad2f9b370bd5bb6f4ee"
-
 original@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/original/-/original-1.0.2.tgz#e442a61cffe1c5fd20a65f3261c26663b303f25f"
@@ -6243,12 +6312,6 @@ os-browserify@^0.3.0:
 os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
-
-os-locale@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
-  dependencies:
-    lcid "^1.0.0"
 
 os-locale@^3.0.0:
   version "3.1.0"
@@ -7146,9 +7209,9 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
 
-promise-polyfill@8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.1.0.tgz#30059da54d1358ce905ac581f287e184aedf995d"
+promise-polyfill@8.1.3:
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.1.3.tgz#8c99b3cf53f3a91c68226ffde7bde81d7f904116"
 
 promise-polyfill@^6.0.2:
   version "6.1.0"
@@ -7194,14 +7257,23 @@ property-information@^5.0.0, property-information@^5.0.1:
   dependencies:
     xtend "^4.0.1"
 
-protobufjs@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-5.0.3.tgz#e4dfe9fb67c90b2630d15868249bcc4961467a17"
+protobufjs@^6.8.6:
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.10.1.tgz#e6a484dd8f04b29629e9053344e3970cccf13cd2"
   dependencies:
-    ascli "~1"
-    bytebuffer "~5"
-    glob "^7.0.5"
-    yargs "^3.10.0"
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/long" "^4.0.1"
+    "@types/node" "^13.7.0"
+    long "^4.0.0"
 
 proxy-addr@~2.0.5:
   version "2.0.5"
@@ -7975,6 +8047,10 @@ semver@^6.0.0, semver@^6.1.0:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.1.1.tgz#53f53da9b30b2103cd4f15eab3a18ecbcb210c9b"
 
+semver@^6.2.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+
 send@0.17.1:
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/send/-/send-0.17.1.tgz#c1d8b059f7900f7466dd4938bdc44e11ddb376c8"
@@ -8684,9 +8760,9 @@ ts-pnp@1.1.2, ts-pnp@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.2.tgz#be8e4bfce5d00f0f58e0666a82260c34a57af552"
 
-tslib@1.9.3:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+tslib@^1.11.1:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
 
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.10.0"
@@ -9196,10 +9272,6 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2 || 2"
 
-window-size@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.4.tgz#f8e1aa1ee5a53ec5bf151ffa09742a6ad7697876"
-
 wordwrap@~0.0.2:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
@@ -9404,10 +9476,6 @@ xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 
-y18n@^3.2.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
-
 "y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
@@ -9462,15 +9530,3 @@ yargs@^12.0.2:
     which-module "^2.0.0"
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
-
-yargs@^3.10.0:
-  version "3.32.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.32.0.tgz#03088e9ebf9e756b69751611d2a5ef591482c995"
-  dependencies:
-    camelcase "^2.0.1"
-    cliui "^3.0.3"
-    decamelize "^1.1.1"
-    os-locale "^1.4.0"
-    string-width "^1.0.1"
-    window-size "^0.1.4"
-    y18n "^3.2.0"


### PR DESCRIPTION
A mess of a PR that haphazardly adds:

* Introduces two new object types under `/years/{year}`:
  * `/years/{year}/awardCategories`, which simply have a name (e.g. "Pixels Matter")
  * `/years/{year}/votes`, which represents a single vote by a user for a project/awardCategory
* Modifies the `/years/{year}/awards` object type to reference `awardCategory` instead of designating the category using a string
* Adds a single property, `votingEnabled` under `/years/{year}` that indicates whether voting is currently active
* A new administrative page, "Award Categories", for creating and editing `awardCategories`
* Modifies ProjectDetails to show a "voting" dropdown (when `votingEnabled` is true), which creates new vote objects
* Modifies ProjectList to show an alert block when voting is enabled
* Modifies ProjectList to show the current user which projects they've voted for

![image](https://user-images.githubusercontent.com/2153/89495294-d9477480-d76c-11ea-85a6-41e74db8d99b.png)
