### PR TITLE
Prevent duplicate votes and self-voting

### DIFF
--- a/database.rules.bolt
+++ b/database.rules.bolt
@@ -85,7 +85,7 @@ type Vote {
     awardCategory: AwardCategoryRef,
     ts: Number
 
-    validate() { $voteId == this.creator + ':' + this.awardCategory }
+    validate() { ($voteId == this.creator + ':' + this.awardCategory) && this.parent().parent().projects[this.project].members[auth.uid] == null }
 }
 
 path / {

--- a/database.rules.bolt
+++ b/database.rules.bolt
@@ -84,6 +84,8 @@ type Vote {
     project: ProjectRef,
     awardCategory: AwardCategoryRef,
     ts: Number
+
+    validate() { $voteId == this.creator + ':' + this.awardCategory }
 }
 
 path / {


### PR DESCRIPTION
There are two major rule changes in this PR:

### 1. Prevent duplicate votes

Captured by this rule:

```
$voteId == this.creator + ':' + this.awardCategory
```
This prevents a user from creating a vote for more than one award category:

* Keys for votes must be a permutation of `${creatorId}:${awardCategoryId}`
* Validity of `awardCategoryId` is enforced (see: `AwardCategoryRef`)
* Validity of `creatorId` is enforced to be the voting user (see: `UserRef`)
* The contents of the vote must match the key (e.g. the `creator` and `awardCategory` components of the vote match the key)

What this does _not_ prevent:

* A user being able to vote for the same project for all categories (since this still fits the constraint)

### 2. Prevent voting for ones own project

```
this.parent().parent().projects[this.project].members[auth.uid] == null
```

This says: the authenticated user (who is casting the vote) must not be found in the project's list of members.