### PR TITLE
Adding Groups

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,6 @@ jobs:
       - name: Install Dependencies
         run: npm install
 
-      - name: Install Dependencies
-        run: npm install
-
       - name: Build
         run: npm run build
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,19 @@ Welcome to #hackweek!
 
 To get the project running:
 
-```
+```bash
 npm install && npm start
 ```
 
-The Hackweek site uses firebase, so deploy it you'll need Google credentials.
+The Hackweek site uses firebase, so to deploy it you'll need Google credentials.
+
+## Deployment
+
+For dev deployments:
+
+```bash
+npm run build && npm run deploy-dev
+```
+
+> [!NOTE]
+> You don't need to run dev deploys if you don't change the `database.rules.bolt` file.

--- a/database.rules.bolt
+++ b/database.rules.bolt
@@ -54,12 +54,24 @@ type Project {
     needHelp: Boolean | Null,
     needHelpComments: String | Null,
     year: String,
+    group: GroupRef | Null,
 
     validate() { prior(this.members) == null || prior(this.members[auth.uid]) != null || isAdmin() }
 }
 
 type ProjectRef extends String {
-  validate() { this.parent().parent().parent().projects[this] != null }
+    validate() { this.parent().parent().parent().projects[this] != null }
+}
+
+type Group {
+    name: String,
+    year: String,
+    creator: InitialUserRef,
+    ts: InitialTimestamp
+}
+
+type GroupRef extends String {
+    validate() { this.parent().parent().parent().groups[this] != null }
 }
 
 type AwardCategoryRef extends String {
@@ -125,6 +137,11 @@ path /years/{year} is Year {
     path /votes/{voteId} is Vote {
         write() { isAllowedUser() && canVote(year) }
         index() { ["creator", "awardCategory"]}
+    }
+
+    path /groups/{groupId} is Group {
+      write() { isAdmin() }
+      index() { ["name"] }
     }
 
     write() { isAdmin() }

--- a/database.rules.bolt
+++ b/database.rules.bolt
@@ -139,7 +139,14 @@ path /years/{year} is Year {
         index() { ["creator", "awardCategory"]}
     }
 
-    path /groups/{groupId} is Group {
+    path /groups {
+      read() { isAllowedUser() }
+      write() { isAdmin() }
+      index() { ["name"] }
+    }
+
+    path /groups/{groupid} is Group {
+      read() { isAllowedUser() }
       write() { isAdmin() }
       index() { ["name"] }
     }

--- a/src/pages/EditProject.js
+++ b/src/pages/EditProject.js
@@ -33,7 +33,7 @@ class EditProject extends Component {
     this.state = {loaded: false, pendingUploads: [], saving: false};
   }
 
-  componentWillReceiveProps({auth, location, project, userList}) {
+  componentWillReceiveProps({auth, location, project, groupsList, userList}) {
     if (project === null) {
       this.context.router.push('/');
     }
@@ -88,7 +88,7 @@ class EditProject extends Component {
     firebase
       .update(`/years/${params.year || currentYear}/projects/${params.projectKey}`, {
         name: this.state.name,
-        group: this.state.group,
+        group: this.state.group.value,
         summary: this.state.summary,
         repository: this.state.repository || '',
         isIdea: this.state.isIdea,
@@ -220,7 +220,7 @@ class EditProject extends Component {
   };
 
   render() {
-    let {firebase, params, project, userList} = this.props;
+    let {firebase, params, project, userList, groupsList} = this.props;
     if (!this.state.loaded) return <div className="loading-indocator">Loading...</div>;
     if (project === null) return <Layout />;
 
@@ -229,7 +229,7 @@ class EditProject extends Component {
       label: user.displayName,
     }));
 
-    let groupOptions = mapObject(groupList, (group, groupKey) => ({
+    let groupOptions = mapObject(groupsList, (group, groupKey) => ({
       value: groupKey,
       label: group.name,
     }));

--- a/src/pages/ManageGroups.js
+++ b/src/pages/ManageGroups.js
@@ -6,6 +6,7 @@ import {compose} from 'redux';
 import {firebaseConnect, isLoaded, pathToJS} from 'react-redux-firebase';
 
 import {mapObject, orderedPopulatedDataToJS} from '../helpers';
+import {currentYear} from '../config';
 
 class GroupRow extends Component {
   static propTypes = {
@@ -126,6 +127,7 @@ class ManageGroups extends Component {
           name: group.name,
           ts: Date.now(),
           creator: auth.uid,
+          year: currentYear,
         })
         .then(onSuccess);
     }

--- a/src/pages/ManageGroups.js
+++ b/src/pages/ManageGroups.js
@@ -1,0 +1,175 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+
+import {connect} from 'react-redux';
+import {compose} from 'redux';
+import {firebaseConnect, isLoaded, pathToJS} from 'react-redux-firebase';
+
+import {mapObject, orderedPopulatedDataToJS} from '../helpers';
+
+class GroupRow extends Component {
+  static propTypes = {
+    group: PropTypes.object,
+    onDelete: PropTypes.func.isRequired,
+    onSave: PropTypes.func.isRequired,
+    year: PropTypes.string.isRequired,
+  };
+
+  static contextTypes = {
+    router: PropTypes.object.isRequired,
+  };
+
+  constructor(props, ...args) {
+    super(props, ...args);
+    this.state = {
+      name: '',
+      ...(props.group || {}),
+    };
+  }
+
+  onChangeField = (e) => {
+    this.setState({
+      [e.target.name]: e.target.value,
+    });
+  };
+
+  hasChanges() {
+    let {group} = this.props;
+    let state = this.state;
+    if (!group) return state.name;
+    return group.name !== state.name;
+  }
+
+  onSuccess = () => {
+    if (!this.props.group) {
+      this.setState({name: ''});
+    }
+  };
+
+  render() {
+    let {group} = this.props;
+    return (
+      <form
+        onSubmit={(e) =>
+          e.preventDefault() && this.props.onSave(this.state, this.onSuccess)
+        }
+        className="form Group-Form"
+      >
+        <div className="row">
+          <div className="col-sm-5">
+            <input
+              className="form-control"
+              type="text"
+              name="name"
+              value={this.state.name}
+              onChange={this.onChangeField}
+              required
+            />
+          </div>
+          <div className="col-sm-2">
+            <button
+              className="btn btn-primary"
+              disabled={!this.hasChanges()}
+              onClick={() => this.props.onSave(this.state, this.onSuccess)}
+            >
+              <span className="glyphicon glyphicon-ok" />
+            </button>
+            {!!group && (
+              <button
+                className="btn btn-danger"
+                style={{marginLeft: 5}}
+                onClick={() => this.props.onDelete(this.state)}
+              >
+                <span className="glyphicon glyphicon-remove" />
+              </button>
+            )}
+          </div>
+        </div>
+      </form>
+    );
+  }
+}
+
+class ManageGroups extends Component {
+  static propTypes = {
+    auth: PropTypes.object,
+    groupsList: PropTypes.object,
+    firebase: PropTypes.object,
+  };
+
+  static contextTypes = {
+    router: PropTypes.object.isRequired,
+  };
+
+  constructor(...args) {
+    super(...args);
+    this.state = {};
+  }
+
+  onDelete = (group) => {
+    let {firebase, params} = this.props;
+    firebase.remove(`/years/${params.year}/groups/${group.key}`);
+  };
+
+  onSave = (group, onSuccess) => {
+    let {auth, firebase, params} = this.props;
+    let {year} = params;
+    if (group.key) {
+      firebase
+        .update(`/years/${year}/groups/${group.key}`, {
+          name: group.name,
+        })
+        .then(onSuccess);
+    } else {
+      firebase
+        .push(`/years/${year}/groups`, {
+          name: group.name,
+          ts: Date.now(),
+          creator: auth.uid,
+        })
+        .then(onSuccess);
+    }
+  };
+
+  render() {
+    let {groupsList, auth} = this.props;
+    if (!isLoaded(auth) || !isLoaded(groupsList))
+      return <div className="loading-indocator">Loading...</div>;
+
+    let {year} = this.props.params;
+
+    return (
+      <div>
+        {mapObject(groupsList)
+          .sort((a, b) => ('' + a.name).localeCompare(b.name))
+          .map((group) => (
+            <GroupRow
+              key={group.key}
+              grup={group}
+              onSave={this.onSave}
+              onDelete={this.onDelete}
+              year={year}
+            />
+          ))}
+        <GroupRow onSave={this.onSave} onDelete={this.onDelete} year={year} />
+      </div>
+    );
+  }
+}
+
+const keyPopulates = [{keyProp: 'key'}];
+
+export default compose(
+  firebaseConnect(({params}) => [
+    {
+      path: `/years/${params.year}/groups`,
+      queryParams: ['orderByValue=name'],
+      populates: keyPopulates,
+      storeAs: 'groupsList',
+    },
+  ]),
+  connect(({firebase}) => ({
+    auth: pathToJS(firebase, 'auth'),
+    groupsList: orderedPopulatedDataToJS(firebase, 'groupsList', keyPopulates),
+  }))
+)(ManageGroups);

--- a/src/pages/ManageYear.js
+++ b/src/pages/ManageYear.js
@@ -38,6 +38,7 @@ class ManageYear extends Component {
           </ListLink>
           <ListLink to={`/admin/years/${yearKey}/awards`}>Awards</ListLink>
           <ListLink to={`/admin/years/${yearKey}/votes`}>Votes</ListLink>
+          <ListLink to={`/admin/years/${yearKey}/groups`}>Groups</ListLink>
         </ul>
         {this.props.children}
       </Layout>

--- a/src/pages/NewProject.js
+++ b/src/pages/NewProject.js
@@ -17,6 +17,7 @@ class NewProject extends Component {
   static propTypes = {
     auth: PropTypes.object,
     userList: PropTypes.object,
+    groupsList: PropTypes.object,
   };
 
   static contextTypes = {
@@ -44,7 +45,7 @@ class NewProject extends Component {
     }
   }
 
-  onSubmit = e => {
+  onSubmit = (e) => {
     e.preventDefault();
 
     let {auth, firebase} = this.props;
@@ -56,11 +57,12 @@ class NewProject extends Component {
         needHelp: this.state.needHelp || false,
         needHelpComments: this.state.needHelpComments || '',
         isIdea: this.state.isIdea || false,
+        group: this.state.group,
         year: currentYear,
         ts: Date.now(),
         creator: auth.uid,
       })
-      .then(snapshot => {
+      .then((snapshot) => {
         let projectKey = snapshot.key;
         let updates = {};
         this.state.team.forEach(({value}) => {
@@ -84,24 +86,33 @@ class NewProject extends Component {
       });
   };
 
-  onChangeField = e => {
+  onChangeField = (e) => {
     this.setState({
       [e.target.name]: e.target.value,
     });
   };
 
-  onChangeTeam = team => {
+  onChangeTeam = (team) => {
     this.setState({team});
   };
 
+  onChangeGroup = (group) => {
+    this.setState({group});
+  };
+
   render() {
-    let {auth, userList} = this.props;
-    if (!isLoaded(auth) || !isLoaded(userList))
+    let {auth, userList, groupsList} = this.props;
+    if (!isLoaded(auth) || !isLoaded(userList) || !isLoaded(groupsList))
       return <div className="loading-indocator">Loading...</div>;
 
-    let options = mapObject(userList, (user, userKey) => ({
+    let teamOptions = mapObject(userList, (user, userKey) => ({
       value: userKey,
       label: user.displayName,
+    }));
+
+    let groupOptions = mapObject(groupsList, (group, groupKey) => ({
+      value: groupKey,
+      label: group.name,
     }));
 
     return (
@@ -116,6 +127,17 @@ class NewProject extends Component {
               name="name"
               value={this.state.name}
               onChange={this.onChangeField}
+              required
+            />
+          </div>
+          <div className="form-group">
+            <label>Group</label>
+            <Select
+              name="group"
+              value={this.state.group}
+              multi={false}
+              options={groupOptions}
+              onChange={this.onChangeGroup}
               required
             />
           </div>
@@ -137,7 +159,7 @@ class NewProject extends Component {
                   type="checkbox"
                   name="isIdea"
                   checked={this.state.isIdea}
-                  onChange={e => {
+                  onChange={(e) => {
                     this.setState({isIdea: e.target.checked});
                   }}
                 />{' '}
@@ -153,7 +175,7 @@ class NewProject extends Component {
                   name="team"
                   value={this.state.team}
                   multi={true}
-                  options={options}
+                  options={teamOptions}
                   onChange={this.onChangeTeam}
                 />
               </div>
@@ -165,7 +187,7 @@ class NewProject extends Component {
                       type="checkbox"
                       name="needHelp"
                       checked={this.state.needHelp}
-                      onChange={e => {
+                      onChange={(e) => {
                         this.setState({needHelp: e.target.checked});
                       }}
                     />{' '}
@@ -206,9 +228,16 @@ export default compose(
       populates: [],
       storeAs: 'userList',
     },
+    {
+      path: `/years/${currentYear}/groups`,
+      queryParams: ['orderByValue=name'],
+      populates: [],
+      storeAs: 'groupsList',
+    },
   ]),
   connect(({firebase}) => ({
     auth: pathToJS(firebase, 'auth'),
     userList: orderedPopulatedDataToJS(firebase, 'userList'),
+    groupsList: orderedPopulatedDataToJS(firebase, 'groupsList'),
   }))
 )(NewProject);

--- a/src/pages/NewProject.js
+++ b/src/pages/NewProject.js
@@ -57,7 +57,7 @@ class NewProject extends Component {
         needHelp: this.state.needHelp || false,
         needHelpComments: this.state.needHelpComments || '',
         isIdea: this.state.isIdea || false,
-        group: this.state.group,
+        group: this.state.group?.value,
         year: currentYear,
         ts: Date.now(),
         creator: auth.uid,

--- a/src/pages/ProjectDetails.js
+++ b/src/pages/ProjectDetails.js
@@ -97,6 +97,7 @@ class ProjectDetails extends Component {
     firebase: PropTypes.object,
     profile: PropTypes.object,
     project: PropTypes.object,
+    groupsList: PropTypes.object,
     userList: PropTypes.object,
     awardCategoryList: PropTypes.object,
   };
@@ -174,9 +175,11 @@ class ProjectDetails extends Component {
     return (this.props.project.members || {}).hasOwnProperty(this.props.auth.uid);
   }
   render() {
-    let {awardList, firebase, params, profile, project, userList, year} = this.props;
+    let {awardList, firebase, params, profile, project, groupsList, userList, year} =
+      this.props;
     if (
       !isLoaded(project) ||
+      !isLoaded(groupsList) ||
       !isLoaded(userList) ||
       !isLoaded(awardList) ||
       !isLoaded(profile) ||
@@ -190,6 +193,8 @@ class ProjectDetails extends Component {
         return userList[memberKey];
       })
       .filter((member) => member !== null);
+
+    let group = groupsList?.[project.group];
 
     projectMembers.sort((a, b) => ('' + a.displayName).localeCompare(b.displayName));
     // XXX(dcramer): not sure why this would happen
@@ -361,6 +366,8 @@ class ProjectDetails extends Component {
                   ]}
                   <dt>Created On</dt>
                   <dd>{moment(project.ts).format('ll')}</dd>
+                  <dt>Group</dt>
+                  <dd>{group?.name}</dd>
                 </dl>
               </div>
             </div>
@@ -392,6 +399,12 @@ export default compose(
       storeAs: 'userList',
     },
     {
+      path: `/years/${props.params.year || currentYear}/groups`,
+      queryParams: ['orderByValue=name'],
+      populates: [],
+      storeAs: 'groupsList',
+    },
+    {
       path: `/years/${props.params.year || currentYear}/projects/${
         props.params.projectKey
       }`,
@@ -410,6 +423,7 @@ export default compose(
       year: orderedPopulatedDataToJS(firebase, 'year'),
       awardList: orderedPopulatedDataToJS(firebase, 'awardList', keyPopulates),
       project: orderedPopulatedDataToJS(firebase, 'project'),
+      groupsList: orderedPopulatedDataToJS(firebase, 'groupsList'),
       userList: orderedPopulatedDataToJS(firebase, 'userList'),
       awardCategoryList: orderedPopulatedDataToJS(firebase, 'awardCategoryList'),
     };

--- a/src/pages/ProjectList.css
+++ b/src/pages/ProjectList.css
@@ -2,6 +2,20 @@
   margin-bottom: 20px;
 }
 
+.filter-groups {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+  border-top: 1px solid black;
+  border-bottom: 1px solid black;
+  padding: 1rem 0;
+}
+
+.filter-groups .Select {
+  min-width: 150px;
+}
+
 .New-Project-Form {
   border: 3px solid #000;
   border-radius: 4px;

--- a/src/routes.js
+++ b/src/routes.js
@@ -12,6 +12,7 @@ import YearList from './pages/YearList';
 import Admin from './pages/Admin';
 import ManageAwardCategories from './pages/ManageAwardCategories';
 import ManageAwards from './pages/ManageAwards';
+import ManageGroups from './pages/ManageGroups';
 import ManageVotes from './pages/ManageVotes';
 import ManageYear from './pages/ManageYear';
 import ManageYearDetails from './pages/ManageYearDetails';
@@ -52,6 +53,7 @@ export default (
       />
       <Route path="/admin/years/:year/votes" component={loginRequired(ManageVotes)} />
       <Route path="/admin/years/:year/awards" component={loginRequired(ManageAwards)} />
+      <Route path="/admin/years/:year/groups" component={loginRequired(ManageGroups)} />
     </Route>
   </Route>
 );


### PR DESCRIPTION
This PR adds the "Groups" feature where every project needs to have a group assigned. Details:
- Added a new `Group` model and a reference to it in the `Project` model
- Only Admin users can create/update/delete groups
- Added a new `Group` tab in the Admin section that renders the `ManageGroups` component
- Added a "Group" input in both New Project and Edit Project screens
- Added a "Group" section in the Project Details Metadata
- Added a group filter in the Projects List screen

Video: 

https://github.com/user-attachments/assets/15e347ce-5519-4fdc-bcf1-8467d2a145d4

