### PR TITLE
fix: More defensively  match videoUrl

### DIFF
--- a/src/pages/ProjectDetails.js
+++ b/src/pages/ProjectDetails.js
@@ -326,6 +326,9 @@ class ProjectDetails extends Component {
 
     let awards = mapObject(awardList).filter((award) => award.project === projectKey);
 
+    const videoUrlMatch = project.videoUrl?.match(
+      /https:\/\/drive\.google\.com\/file\/d\/(.*)\/[a-z]*.*/
+    );
     return (
       <Layout>
         <div className="Project-Details">
@@ -341,20 +344,17 @@ class ProjectDetails extends Component {
           </div>
           <div className="Project-Details-Content">
             <div className="Project-Details-Content-main">
-              {project.videoUrl &&
-                project.videoUrl.match(
-                  /https:\/\/drive\.google\.com\/file\/d\/(.*)\/[a-z]*.*/
-                )[1] && (
-                  <iframe
-                    src={`https://drive.google.com/file/d/${
-                      project.videoUrl.match(
-                        /https:\/\/drive\.google\.com\/file\/d\/(.*)\/[a-z]*.*/
-                      )[1]
-                    }/preview`}
-                    allow="autoplay"
-                    style={{width: '100%', aspectRatio: '16/9'}}
-                  ></iframe>
-                )}
+              {project.videoUrl && videoUrlMatch && videoUrlMatch[1] && (
+                <iframe
+                  src={`https://drive.google.com/file/d/${
+                    project.videoUrl.match(
+                      /https:\/\/drive\.google\.com\/file\/d\/(.*)\/[a-z]*.*/
+                    )[1]
+                  }/preview`}
+                  allow="autoplay"
+                  style={{width: '100%', aspectRatio: '16/9'}}
+                ></iframe>
+              )}
               <h2>Summary</h2>
               <div
                 className="Project-details-summary no-forced-lowercase"


### PR DESCRIPTION
I accidentally copied an unexpected Google Drive URL into my hackweek projects "videUrl" form field. After saving, I could no longer look at my project because the react component errored when it tried to use matches from `videoUrl` without checking if we mached anything. This PR just makes sure we actually check the regexp match before using parts of it. 

side-note. We might wanna upgrade the Sentry SDK from v6 at some point :D It tried sending the error but it still sends it to the pre-envelope `/store`. Which errors because apparently the payload is too large (not sure if this is a relay bug tbh).  