### PR TITLE
chore: redirect legacy site to new domain

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -17,10 +17,11 @@
         ]
       }
     ],
-    "rewrites": [
+    "redirects": [
       {
         "source": "**",
-        "destination": "/index.html"
+        "destination": "https://hackweek.sentry.new",
+        "type": 302
       }
     ]
   },


### PR DESCRIPTION
## Summary
- replace the legacy Firebase Hosting SPA rewrite with a catch-all redirect
- send legacy traffic to `https://hackweek.sentry.new`
- use a temporary `302` redirect so the cutover remains easy to verify and roll back

## Validation
- `firebase.json` parses as valid JSON
- `git diff --check`
