### PR TITLE
fix(ci): update release workflow actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache node modules
         id: cache-npm
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
@@ -41,7 +41,7 @@ jobs:
         run: npm run bind-version
 
       - name: Archive Production Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: build
@@ -51,10 +51,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
           path: build


### PR DESCRIPTION
## Summary
- update the release workflow's artifact upload and download actions from v3 to v4
- update checkout and cache to their supported v4 releases
- unblock the Firebase redirect deployment added by #130

## Root cause
The post-merge Release run failed during job setup because GitHub now rejects `actions/upload-artifact@v3` before any build steps run.

Failed run: https://github.com/getsentry/hackweek/actions/runs/31466440839

## Validation
- `actionlint .github/workflows/release.yml`
- parsed `.github/workflows/release.yml` as YAML
- `git diff --check`
