### PR TITLE
feat: deploy Cloudflare production from master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,10 @@
-name: Deploy Cloudflare environment
+name: Deploy Cloudflare production
 
 on:
+  push:
+    branches:
+      - master
   workflow_dispatch:
-    inputs:
-      confirm:
-        description: Type deploy-hackweek after operator review
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -17,11 +15,11 @@ concurrency:
 
 jobs:
   verify:
-    if: inputs.confirm == 'deploy-hackweek'
+    if: github.ref == 'refs/heads/master'
     uses: ./.github/workflows/test.yml
 
   deploy:
-    name: Deploy reviewed configuration
+    name: Deploy production
     needs: verify
     runs-on: ubuntu-latest
     environment: hackweek-cloudflare

--- a/README.md
+++ b/README.md
@@ -7,6 +7,17 @@ Hackweek is an internal React + TypeScript application served by one Hono Cloudf
 - Node.js 24.11 or newer (Volta and CI pin 24.19)
 - npm 11 or newer
 
+## Deployment
+
+Every push to `master` runs the full verification suite, applies pending D1 migrations, and deploys the Worker and static assets to Cloudflare production through [`.github/workflows/deploy.yml`](.github/workflows/deploy.yml). The workflow can also be retried manually from `master`; other refs cannot deploy production.
+
+The workflow requires these GitHub Actions secrets:
+
+- `CLOUDFLARE_ACCOUNT_ID`: the Sentry Production Cloudflare account ID.
+- `CLOUDFLARE_API_TOKEN`: an account-scoped token with **Edit Cloudflare Workers** and **D1 Edit** permissions.
+
+Production deploys use [`wrangler.production.json`](wrangler.production.json) and the `hackweek-cloudflare` GitHub environment. Do not add Cloudflare credentials to the repository.
+
 ## Deterministic local start
 
 ```bash


### PR DESCRIPTION
## Summary

- deploy Cloudflare production automatically on every push to `master`
- run the full reusable verification workflow before applying D1 migrations and deploying the Worker/static assets
- retain a safe manual retry path that can only deploy `master`
- document the production workflow and required GitHub Actions secrets

## Repository setup

- `CLOUDFLARE_ACCOUNT_ID` is configured for the Sentry Production account
- `CLOUDFLARE_API_TOKEN` must be added before this PR is merged; it should be account-scoped with **Edit Cloudflare Workers** and **D1 Edit** permissions

This PR is a draft until the API token secret is configured, because merging it will immediately start the first production deployment.

## Verification

- `actionlint .github/workflows/deploy.yml .github/workflows/test.yml`
- `npm run verify`
  - typecheck, formatting, and lint passed
  - 114 automated tests passed
  - production build and Cloudflare deploy dry run passed
  - all six D1 migrations and 22 local readiness checks passed
